### PR TITLE
Add logo

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,1 +1,2 @@
 site_title: Ubuntu Core documentation
+site_logo_url: https://assets.ubuntu.com/v1/c5cb0f8e-picto-ubuntu.svg


### PR DESCRIPTION
There doesn't seem to be a specific logo for ubuntu core, instead it's just the circle of friends.

So I'm adding in a basic circle of friends SVG.

QA
--

``` bash
documentation-builder
xdg-open build/en/index.html
```

Look at the logo. Just look at it!