### PR TITLE
Add Ubuntu Core Stacks bits as a new subsection

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,25 @@
 This documentation will walk you through the steps of building and managing an Ubuntu Core device.
 
 You can find it published on [docs.ubuntu.com/core](http://docs.ubuntu.com/core).
+
+# Building
+
+To build the documentation you need to install documentation-builder:
+
+    $ snap install documentation-builder
+
+Then install the git-repo utility:
+
+    $ mkdir $HOME/.bin/
+    $ export PATH=\$PATH:$HOME/.bin/repo >> $HOME/bashrc
+    $ curl https://storage.googleapis.com/git-repo-downloads/repo > $HOME/.bin/repo
+    $ chmod a+x $HOME/.bin/repo
+
+From the root of the documentation source tree do the following to get the Ubuntu
+Core Stacks bits:
+
+    $ repo init -u git@github.com:CanonicalLtd/ubuntu-core-docs.git
+    $ repo sync
+    $ documentation-builder
+
+All of the generated documentation will be under build/

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ To build the documentation you need to install documentation-builder:
 Then install the git-repo utility:
 
     $ mkdir $HOME/.bin/
-    $ export PATH=\$PATH:$HOME/.bin/repo >> $HOME/bashrc
+    $ export PATH=$PATH:$HOME/.bin/repo
     $ curl https://storage.googleapis.com/git-repo-downloads/repo > $HOME/.bin/repo
     $ chmod a+x $HOME/.bin/repo
 

--- a/default.xml
+++ b/default.xml
@@ -11,7 +11,6 @@
   <project path="en/stacks/audio/pulseaudio" name="pulseaudio" />
   <project path="en/stacks/tpm/tpm" name="tpm" />
   <project path="en/stacks/tpm/tpm2" name="tpm2" />
-  <project path="en/stacks/disk/udisks" name="udisks" />
   <project path="en/stacks/disk/udisks2" name="udisks2" />
   <project path="en/stacks/power" name="upower" />
   <project path="en/stacks/testing" name="engineering-tests" />

--- a/default.xml
+++ b/default.xml
@@ -4,8 +4,10 @@
   <default revision="master" remote="origin"  sync-j="4" />
   <project path="en/stacks/audio/alsa" name="alsa-utils" />
   <project path="en/stacks/bluetooth" name="bluez" />
-  <project path="en/stacks/modem" name="modem-manager" />
-  <project path="en/stacks/network" name="network-manager" />
+  <project path="en/stacks/network/modem-manager" name="modem-manager" />
+  <project path="en/stacks/network/network-manager" name="network-manager" />
+  <project path="en/stacks/network/ofono" name="ofono" />
+  <project path="en/stacks/network/wifi-ap" name="wifi-ap" />
   <project path="en/stacks/audio/pulseaudio" name="pulseaudio" />
   <project path="en/stacks/tpm/tpm" name="tpm" />
   <project path="en/stacks/tpm/tpm2" name="tpm2" />
@@ -13,5 +15,4 @@
   <project path="en/stacks/disk/udisks2" name="udisks2" />
   <project path="en/stacks/power" name="upower" />
   <project path="en/stacks/testing" name="engineering-tests" />
-  <project path="en/stacks/wifi" name="wifi-ap" />
 </manifest>

--- a/default.xml
+++ b/default.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+  <remote name="origin" fetch="https://git.launchpad.net/~snappy-hwe-team/snappy-hwe-snaps/+git" />
+  <default revision="master" remote="origin"  sync-j="4" />
+  <project path="en/stacks/audio/alsa" name="alsa-utils" />
+  <project path="en/stacks/bluetooth" name="bluez" />
+  <project path="en/stacks/modem" name="modem-manager" />
+  <project path="en/stacks/network" name="network-manager" />
+  <project path="en/stacks/audio/pulseaudio" name="pulseaudio" />
+  <project path="en/stacks/tpm/tpm" name="tpm" />
+  <project path="en/stacks/tpm/tpm2" name="tpm2" />
+  <project path="en/stacks/disk/udisks" name="udisks" />
+  <project path="en/stacks/disk/udisks2" name="udisks2" />
+  <project path="en/stacks/power" name="upower" />
+  <project path="en/stacks/testing" name="engineering-tests" />
+  <project path="en/stacks/wifi" name="wifi-ap" />
+</manifest>

--- a/en/metadata.yaml
+++ b/en/metadata.yaml
@@ -53,6 +53,11 @@ navigation:
       - title: Introduction
         location: stacks/index.md
 
+# TODO:
+#   * Need Markdown documentation for location-service
+#   * Need Markdown documentation for media-hub
+#   * Need Markdown documentation for upower
+#   * Need to move the wifi-ap documentation from Google Docs to Markdown
       - title: Stack Items
         children:
           - title: Audio management
@@ -61,13 +66,13 @@ navigation:
             location: stacks/bluetooth/doc/overview.md
           - title: Disk management
             location: stacks/disk/index.md
-          - title: Location services
+#          - title: Location services
 #            location: stacks/location/docs/index.md
-          - title: Media playback & recording
+#          - title: Media playback & recording
 #            location: stacks/media/docs/index.md
           - title: Network management & services
             location: stacks/network/index.md
-          - title: Power management
+#          - title: Power management
 #            location: stacks/power/docs/index.md
           - title: TPM
             location: stacks/tpm/index.md

--- a/en/metadata.yaml
+++ b/en/metadata.yaml
@@ -65,16 +65,12 @@ navigation:
 #            location: stacks/location/docs/index.md
           - title: Media playback & recording
 #            location: stacks/media/docs/index.md
-          - title: Modem management
-#            location: stacks/modem/docs/index.md
-          - title: Network management
-            location: stacks/network/docs/index.md
+          - title: Network management & services
+            location: stacks/network/index.md
           - title: Power management
 #            location: stacks/power/docs/index.md
           - title: TPM
             location: stacks/tpm/index.md
-          - title: WiFi access point
-#            location: stacks/wifi/docs/index.md
 
 #      - title: Debugging
 

--- a/en/metadata.yaml
+++ b/en/metadata.yaml
@@ -56,9 +56,25 @@ navigation:
       - title: Stack Items
         children:
           - title: Audio management
-          - location: audio/index.md
+            location: stacks/audio/index.md
           - title: Bluetooth management
-          - location: bluetooth/index.md
+            location: stacks/bluetooth/doc/overview.md
+          - title: Disk management
+            location: stacks/disk/index.md
+          - title: Location services
+#            location: stacks/location/docs/index.md
+          - title: Media playback & recording
+#            location: stacks/media/docs/index.md
+          - title: Modem management
+            location: stacks/modem/docs/index.md
+          - title: Network management
+            location: stacks/network/docs/index.md
+          - title: Power management
+#            location: stacks/power/docs/index.md
+          - title: TPM
+            location: tpm/index.md
+          - title: WiFi access point
+#            location: stacks/wifi/docs/index.md
 
 #      - title: Debugging
 

--- a/en/metadata.yaml
+++ b/en/metadata.yaml
@@ -47,6 +47,19 @@ navigation:
       - title: Advanced - Branded store
         location: guides/go-to-production/advanced.md
 
+  - title: Ubuntu Core Stacks
+
+    children:
+      - title: Introduction
+        location: index.md
+
+      - title: Stack Items
+        children:
+          - title: Audio management
+          - location: audio/index.md
+          - title: Bluetooth management
+          - location: bluetooth/index.md
+
 #      - title: Debugging
 
 #  - title: Manage devices

--- a/en/metadata.yaml
+++ b/en/metadata.yaml
@@ -51,7 +51,7 @@ navigation:
 
     children:
       - title: Introduction
-        location: index.md
+        location: stacks/index.md
 
       - title: Stack Items
         children:
@@ -66,13 +66,13 @@ navigation:
           - title: Media playback & recording
 #            location: stacks/media/docs/index.md
           - title: Modem management
-            location: stacks/modem/docs/index.md
+#            location: stacks/modem/docs/index.md
           - title: Network management
             location: stacks/network/docs/index.md
           - title: Power management
 #            location: stacks/power/docs/index.md
           - title: TPM
-            location: tpm/index.md
+            location: stacks/tpm/index.md
           - title: WiFi access point
 #            location: stacks/wifi/docs/index.md
 

--- a/en/stacks/audio/index.md
+++ b/en/stacks/audio/index.md
@@ -6,5 +6,5 @@ title: Audio management
 
 There are currently two different snaps that help manage audio under Ubuntu Core Stacks:
 
-1. ALSA Utils
-2. PulseAudio
+* alsa-utils
+* pulseaudio

--- a/en/stacks/audio/index.md
+++ b/en/stacks/audio/index.md
@@ -1,0 +1,10 @@
+---
+title: Audio management
+---
+
+# Audio management
+
+There are currently two different snaps that help manage audio under Ubuntu Core Stacks:
+
+1. ALSA Utils
+2. PulseAudio

--- a/en/stacks/disk/index.md
+++ b/en/stacks/disk/index.md
@@ -4,8 +4,7 @@ title: Disk management
 
 # Disk management
 
-There are currently two different ways to manage disks and their mount points
-under Ubuntu Core Stacks:
+The following snap is used to manage disks, their mount points,
+partitions, formatting, etc under Ubuntu Core Stacks:
 
-1. udisks
-2. udisks2
+* udisks2

--- a/en/stacks/disk/index.md
+++ b/en/stacks/disk/index.md
@@ -1,0 +1,5 @@
+---
+title: Disk management
+---
+
+# Disk management

--- a/en/stacks/disk/index.md
+++ b/en/stacks/disk/index.md
@@ -3,3 +3,9 @@ title: Disk management
 ---
 
 # Disk management
+
+There are currently two different ways to manage disks and their mount points
+under Ubuntu Core Stacks:
+
+1. udisks
+2. udisks2

--- a/en/stacks/index.md
+++ b/en/stacks/index.md
@@ -2,37 +2,42 @@
 title: What is Ubuntu Stacks?
 ---
 
-# What is Ubuntu Stacks?
+# What is Ubuntu Core Stacks?
 
-Ubuntu Stacks is a set of snap packages that offer system-level functionality that
-enables important core system-level functionality not offered by the base Ubuntu Core
+Ubuntu Core Stacks is a set of snap packages that offer system-level functionality that
+enables important core system-level features not offered by the base Ubuntu Core
 system. With little to no additional effort, these snaps can be dropped in place
-on one or more new or existing systems bringing significant new functionality.
+on existing systems bringing significant new value to these systems.
 These snaps have been well tested in various commercial offerings and are
 actively maintained by an internal Canonical team.
 
-Please note that some additional integration work to these snaps are required if
-new application of these snaps diverges significantly from existing applications.
+Please note that some additional integration work to these snaps may be required if
+new applications of these snaps diverges significantly from existing applications.
 
-You may find the existing source repositories for these snaps as well as where to
-submit contributions to them [here](https://code.launchpad.net/~snappy-hwe-team/snappy-hwe-snaps/).
-You may also file bugs against these snaps [here](https://bugs.launchpad.net/snappy-hwe-snaps).
+# What Ubuntu Core Stacks offers
 
-# What Ubuntu Stacks offers
+Ubuntu Core Stacks currently offers the following areas of functionality relevant
+to many different types of Ubuntu Core-based systems:
 
-Ubuntu Stacks currently offers the following areas of functionality that areas
-relevant to many different types of Ubuntu Core-based systems:
-
-* [Audio device management](audio/index.md)
+* [Audio management](audio/index.md)
 * [Bluetooth device management](bluetooth/doc/overview.md)
-* [Disk mountpoint management](disk/index.md)
+* [Disk management](disk/index.md)
 * Location services (GPS, WiFi, etc)
-* Media playback/recording management
-* Modem device management
-* [Network interface management](network/docs/index.md) (both wired and wireless)
+* Multimedia management
+* Cellular modem device data management
+* [Network interface management](network/network-manager/docs/index.md) (both wired and wireless)
 * Power management for battery-operated devices
 * [TPM](tpm/index.md) [Reference](https://en.wikipedia.org/wiki/Trusted_Platform_Module)
-* WiFi Access Point (AP) system offering
+* WiFi Access Point (AP)
 
 * Extensive manual and automatic testing framework for above functionality via
   [Plainbox](https://pypi.python.org/pypi/plainbox) and [Spread](https://github.com/snapcore/spread)
+
+# Contributing source changes to these snaps
+
+  You may find the existing source repositories for these snaps as well as where to
+  submit contributions to them [here](https://code.launchpad.net/~snappy-hwe-team/snappy-hwe-snaps/).
+  You may also file bugs against these snaps [here](https://bugs.launchpad.net/snappy-hwe-snaps).
+
+  Please see the following documentation which covers how to retrieve and submit sources
+  from Launchpad using git: [getting and pushing code](https://help.launchpad.net/Code/Git#Getting_code)

--- a/en/stacks/index.md
+++ b/en/stacks/index.md
@@ -1,0 +1,38 @@
+---
+title: What is Ubuntu Stacks?
+---
+
+# What is Ubuntu Stacks?
+
+Ubuntu Stacks is a set of snap packages that offer system-level functionality that
+enables important core system-level functionality not offered by the base Ubuntu Core
+system. With little to no additional effort, these snaps can be dropped in place
+on one or more new or existing systems bringing significant new functionality.
+These snaps have been well tested in various commercial offerings and are
+actively maintained by an internal Canonical team.
+
+Please note that some additional integration work to these snaps are required if
+new application of these snaps diverges significantly from existing applications.
+
+You may find the existing source repositories for these snaps as well as where to
+submit contributions to them [here](https://code.launchpad.net/~snappy-hwe-team/snappy-hwe-snaps/).
+You may also file bugs against these snaps [here](https://bugs.launchpad.net/snappy-hwe-snaps).
+
+# What Ubuntu Stacks offers
+
+Ubuntu Stacks currently offers the following areas of functionality that areas
+relevant to many different types of Ubuntu Core-based systems:
+
+* [Audio device management](audio/index.md)
+* [Bluetooth device management](bluetooth/doc/overview.md)
+* [Disk mountpoint management](disk/index.md)
+* Location services (GPS, WiFi, etc)
+* Media playback/recording management
+* Modem device management
+* [Network interface management](network/docs/index.md) (both wired and wireless)
+* Power management for battery-operated devices
+* [TPM](tpm/index.md) [Reference](https://en.wikipedia.org/wiki/Trusted_Platform_Module)
+* WiFi Access Point (AP) system offering
+
+* Extensive manual and automatic testing framework for above functionality via
+  [Plainbox](https://pypi.python.org/pypi/plainbox) and [Spread](https://github.com/snapcore/spread)

--- a/en/stacks/network/index.md
+++ b/en/stacks/network/index.md
@@ -4,9 +4,9 @@ title: Network management & services
 
 # Network management & services
 
-There are currently several interesting snaps which manage networking, modems
-and instantly creates a wireless access point:
+There are currently several snaps which manage networking, modems
+and one that instantly creates a wireless access point:
 
-1. modem-manager
-2. [network-manager](stacks/network/network-manager/docs/index.md)
-3. wifi-ap
+* modem-manager
+* [network-manager](network-manager/docs/index.md)
+* wifi-ap

--- a/en/stacks/network/index.md
+++ b/en/stacks/network/index.md
@@ -1,0 +1,12 @@
+---
+title: Network management & services
+---
+
+# Network management & services
+
+There are currently several interesting snaps which manage networking, modems
+and instantly creates a wireless access point:
+
+1. modem-manager
+2. [network-manager](stacks/network/network-manager/docs/index.md)
+3. wifi-ap

--- a/en/stacks/tpm/index.md
+++ b/en/stacks/tpm/index.md
@@ -7,5 +7,8 @@ title: TPM
 There are currently two different snaps that help manage TPM under Ubuntu Core Stacks
 depending on the version of TPM that your hardware device supports:
 
-1. TPM
-2. TPM2
+* tpm
+* tpm2
+
+[See this page](https://en.wikipedia.org/wiki/Trusted_Platform_Module) for more
+information about TPM.

--- a/en/stacks/tpm/index.md
+++ b/en/stacks/tpm/index.md
@@ -1,0 +1,11 @@
+---
+title: TPM
+---
+
+# Trusted Platform Module (TPM)
+
+There are currently two different snaps that help manage TPM under Ubuntu Core Stacks
+depending on the version of TPM that your hardware device supports:
+
+1. TPM
+2. TPM2


### PR DESCRIPTION
We are using repo to manage sub-git-repositories for the Ubuntu Core Stacks documentation items. I've added documentation in README.md detailing how to fetch these sub-repos. This was the most sane way we could come up with on how to manage all of these various moving parts while not using a monolithic repository duplicating efforts of each snap's documentation.