### PR TITLE
Rename service.sshd.disabled configuration option of the core snap

### DIFF
--- a/en/reference/core-configuration.md
+++ b/en/reference/core-configuration.md
@@ -25,7 +25,7 @@ e.g.:
 
 The following configuration options are currently supported:
 
-## service.sshd.disabled
+## service.ssh.disabled
 
 Disable the SSH service of the system.
 
@@ -46,5 +46,5 @@ The configuration option accepts the following values:
 Example:
 
 ```
- $ snap set core service.sshd.disabled=true
+ $ snap set core service.ssh.disabled=true
 ```

--- a/en/reference/core-configuration.md
+++ b/en/reference/core-configuration.md
@@ -27,6 +27,8 @@ The following configuration options are currently supported:
 
 ## service.ssh.disabled
 
+Available since: 2.22
+
 Disable the SSH service of the system.
 
 **WARNING**: Disabling SSH disables the default way to access an Ubuntu Core


### PR DESCRIPTION
@caldav I've added a note about since which snapd version this option is available. Not sure if this is the right way to do this.