### PR TITLE
Fix repo init URL so that an SSH key installed on github.com isn't required

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Then install the git-repo utility:
 From the root of the documentation source tree do the following to get the Ubuntu
 Core Stacks bits:
 
-    $ repo init -u git@github.com:CanonicalLtd/ubuntu-core-docs.git
+    $ repo init -u https://github.com/CanonicalLtd/ubuntu-core-docs.git
     $ repo sync
     $ documentation-builder
 


### PR DESCRIPTION
Fix repo init URL so that an SSH key installed on github.com isn't required to gain download access.