### PR TITLE
Update location documentation to come from snappy-hwe-snaps

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -11,4 +11,5 @@
   <project path="en/stacks/disk/udisks2" name="udisks2" />
   <project path="en/stacks/power/upower" name="upower" />
   <project path="en/stacks/network/wifi-ap" name="wifi-ap" />
+  <project path="en/stacks/location/location-service" name="location-service" />
 </manifest>

--- a/en/stacks/index.md
+++ b/en/stacks/index.md
@@ -22,7 +22,7 @@ to many different types of Ubuntu Core-based systems:
 * [Audio management](audio/index.md)
 * [Bluetooth device management](bluetooth/index.md)
 * [Disk management](disk/index.md)
-* [Location services](http://locationd.readthedocs.io/en/latest/index.html)
+* [Location services](location/index.md)
 * Multimedia management
 * [Cellular modem device data management](network/modem-manager/docs/index.md)
 * [Network interface management](network/network-manager/docs/index.md) (both wired and wireless)

--- a/en/stacks/location/index.md
+++ b/en/stacks/location/index.md
@@ -1,0 +1,9 @@
+---
+title: Location Services
+---
+
+# Location Services
+
+The following snap is used to manage location services under Ubuntu Core Stacks
+
+* [locationd](location-service/docs/index.md)


### PR DESCRIPTION
We have now more extensive documentation inside location-service itself
and don't want to refer to the limit and incomplete documentation on
readthedocs.

**NOTE** Please don't merge until the corresponding upstream PR at https://code.launchpad.net/~morphis/snappy-hwe-snaps/+git/location-service/+merge/330757 is merged.